### PR TITLE
Fallback to site meta description if excerpt missing

### DIFF
--- a/11ty/_includes/layouts/base.njk
+++ b/11ty/_includes/layouts/base.njk
@@ -10,7 +10,7 @@
 
     <meta
       name="twitter:description"
-      content="{{ flag.level + ": " + socialPreview }}"
+      content="{{ description }}"
     >
 
     <meta name="twitter:card" content="summary"/>
@@ -19,7 +19,7 @@
 
     <meta
       name="og:description"
-      content="{{ flag.level + ": " + socialPreview }}"
+      content="{{ description }}"
     >
 
     <meta name="og:title" content="{{ pageTitle }}"/>

--- a/11ty/_includes/layouts/definition.njk
+++ b/11ty/_includes/layouts/definition.njk
@@ -1,8 +1,8 @@
 {% extends 'layouts/base.njk' %}
 {% set pageType = 'Definition' %}
 {% set titleWithPath = title + ' « Definitions « ' %}
-{% set description = 'The definition of ' + title + ' in Self-Defined, a modern dictionary about us.'%}
-
+{% set description =   (flag.level + ' : ' if flag.level ) +  excerpt if excerpt else 'The definition of ' + title + ' in Self-Defined, a modern dictionary about us.' %}
+ 
 {% block content %}
   <div class="wide-content">
     {% include 'components/sub-page-header.njk' %}

--- a/11ty/definitions/barbaric.md
+++ b/11ty/definitions/barbaric.md
@@ -5,7 +5,7 @@ flag:
   text: 'Neo-Colonial/Racist slur'
   level: 'avoid'
 defined: true
-socialPreview: something which is obscenely cruel; primitive; unsophisticated. 
+excerpt: something which is obscenely cruel; primitive; unsophisticated. 
 speech: adjective
 reading:
   - text: 'is the word barbarian a slur?'


### PR DESCRIPTION
- changed socialPreview to be exercept for more generic usage
- checks if there is a flag present and renders that colon conditionally
- if no socialPreview field present, show the site description